### PR TITLE
Update keys.js with illumination key values

### DIFF
--- a/src/helpers/keys.js
+++ b/src/helpers/keys.js
@@ -129,8 +129,8 @@ export const keys = [
       // @TODO: fix the media control keys below
       // { key: 'mission_control', hex: 0xff0100000007 - 0x700000000 },
       // { key: 'launchpad', hex: 0xff0100000006 - 0x700000000 },
-      // { key: 'illumination_decrement', hex: 0xff0100000008 },
-      // { key: 'illumination_increment', hex: 0xff0100000009 },
+      { key: 'illumination_decrement', hex: 0xFF00000009 },
+      { key: 'illumination_increment', hex: 0xFF00000008 },
       { key: 'rewind', hex: 0xC000000B4 - 0x700000000 },
       { key: 'play_or_pause', hex: 0xC000000CD - 0x700000000 },
       { key: 'fast_forward', hex: 0xC000000B3 - 0x700000000 },


### PR DESCRIPTION
Adds `illumination_decrement` and `illumination_increment` hex codes as of macOS 13.4 Ventura.

The latest M2 macbooks removed hardware media keys for keyboard backlight control which many users may be looking to re-implement via remapping. I've tested that the values for decrementing and incrementing the keyboard backlight work by remapping F5 and F6 keys to decrement and increment respectively using the following command:

`/usr/bin/hidutil property --set "{\"UserKeyMapping\":[{\"HIDKeyboardModifierMappingSrc\": 0x70000003E,\"HIDKeyboardModifierMappingDst\": 0xFF00000009},{\"HIDKeyboardModifierMappingSrc\": 0x70000003F, \"HIDKeyboardModifierMappingDst\": 0xFF00000008}]}"`

Note that I have changed settings in my system preferences to default the keyboard to using function keys and media keys are accessed via using the FN modifier key alongside the desired media key. 